### PR TITLE
日別タスクフィルタリング機能の実装

### DIFF
--- a/__tests__/page.test.tsx
+++ b/__tests__/page.test.tsx
@@ -17,10 +17,15 @@ describe('Todo App', () => {
   })
 
   it('renders the todo app title', async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
-    })
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
 
     await act(async () => {
       render(<Home />)
@@ -30,10 +35,15 @@ describe('Todo App', () => {
   })
 
   it('renders input field and add button', async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
-    })
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
 
     await act(async () => {
       render(<Home />)
@@ -49,10 +59,15 @@ describe('Todo App', () => {
       { id: 2, text: 'Another todo', completed: true, priority: 2 },
     ]
 
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockTodos,
-    })
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTodos,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
 
     await act(async () => {
       render(<Home />)
@@ -60,6 +75,7 @@ describe('Todo App', () => {
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith('/api/todos')
+      expect(fetch).toHaveBeenCalledWith('/api/todos/dates')
     })
 
     expect(screen.getByText('Test todo')).toBeInTheDocument()
@@ -74,11 +90,19 @@ describe('Todo App', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => {},
       })
       .mockResolvedValueOnce({
         ok: true,
         json: async () => [{ id: 1, text: 'New todo', completed: false, priority: 1 }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
       })
 
     await act(async () => {
@@ -110,10 +134,15 @@ describe('Todo App', () => {
   })
 
   it('does not add empty todo', async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
-    })
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
 
     await act(async () => {
       render(<Home />)
@@ -125,8 +154,8 @@ describe('Todo App', () => {
       fireEvent.click(addButton)
     })
 
-    // Should only be called once for initial fetch, not for adding empty todo
-    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    // Should only be called twice for initial fetches, not for adding empty todo
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
   })
 
   it('toggles todo completion', async () => {
@@ -141,11 +170,19 @@ describe('Todo App', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => {},
       })
       .mockResolvedValueOnce({
         ok: true,
         json: async () => [{ id: 1, text: 'Test todo', completed: true, priority: 1 }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
       })
 
     await act(async () => {
@@ -186,7 +223,15 @@ describe('Todo App', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => {},
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -216,6 +261,74 @@ describe('Todo App', () => {
     // Verify the todo item is no longer present in the DOM
     await waitFor(() => {
       expect(screen.queryByText('Test todo')).not.toBeInTheDocument()
+    })
+  })
+
+  it('renders date selector with all button', async () => {
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { date: '2023-01-01', count: 5, completed_count: 3 },
+          { date: '2023-01-02', count: 2, completed_count: 1 },
+        ],
+      })
+
+    await act(async () => {
+      render(<Home />)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('すべて')).toBeInTheDocument()
+    })
+  })
+
+  it('filters todos by date when date tab is clicked', async () => {
+    const mockDateSummaries = [
+      { date: '2023-01-01', count: 2, completed_count: 1 },
+    ]
+    const mockFilteredTodos = [
+      { id: 1, text: 'Filtered todo', completed: false, priority: 1 },
+    ]
+
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDateSummaries,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockFilteredTodos,
+      })
+
+    await act(async () => {
+      render(<Home />)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('2023/01/01 (1/2)')).toBeInTheDocument()
+    })
+
+    const dateButton = screen.getByText('2023/01/01 (1/2)')
+    
+    await act(async () => {
+      fireEvent.click(dateButton)
+    })
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith('/api/todos?date=2023-01-01')
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Filtered todo')).toBeInTheDocument()
     })
   })
 })

--- a/app/api/todos/dates/route.ts
+++ b/app/api/todos/dates/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import db from '@/lib/db'
+
+export async function GET() {
+  try {
+    const [rows] = await db.execute(`
+      SELECT 
+        DATE(created_at) as date,
+        COUNT(*) as count,
+        SUM(CASE WHEN completed = 1 THEN 1 ELSE 0 END) as completed_count
+      FROM todos 
+      GROUP BY DATE(created_at) 
+      ORDER BY DATE(created_at) DESC
+    `)
+    return NextResponse.json(rows)
+  } catch (error) {
+    console.error('Database error:', error)
+    return NextResponse.json({ error: 'Failed to fetch dates' }, { status: 500 })
+  }
+}

--- a/app/api/todos/route.ts
+++ b/app/api/todos/route.ts
@@ -1,9 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server'
 import db from '@/lib/db'
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const [rows] = await db.execute('SELECT * FROM todos ORDER BY priority DESC, created_at DESC')
+    const { searchParams } = new URL(request.url)
+    const date = searchParams.get('date')
+    
+    let query = 'SELECT * FROM todos'
+    let params: any[] = []
+    
+    if (date) {
+      query += ' WHERE DATE(created_at) = ?'
+      params.push(date)
+    }
+    
+    query += ' ORDER BY priority DESC, created_at DESC'
+    
+    const [rows] = await db.execute(query, params)
     return NextResponse.json(rows)
   } catch (error) {
     console.error('Database error:', error)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,25 +9,47 @@ interface Todo {
   text: string
   completed: boolean
   priority: number
+  created_at: string
+}
+
+interface DateSummary {
+  date: string
+  count: number
+  completed_count: number
 }
 
 export default function Home() {
   const [todos, setTodos] = useState<Todo[]>([])
   const [inputText, setInputText] = useState('')
   const [priority, setPriority] = useState(1)
+  const [dateSummaries, setDateSummaries] = useState<DateSummary[]>([])
+  const [selectedDate, setSelectedDate] = useState<string>('')
 
   useEffect(() => {
     fetchTodos()
+    fetchDateSummaries()
   }, [])
 
-  const fetchTodos = async () => {
+  const fetchTodos = async (date?: string) => {
     try {
-      const response = await fetch('/api/todos')
+      const url = date ? `/api/todos?date=${date}` : '/api/todos'
+      const response = await fetch(url)
       const data = await response.json()
       setTodos(Array.isArray(data) ? data : [])
     } catch (error) {
       console.error('Error fetching todos:', error)
       setTodos([])
+    }
+  }
+
+  const fetchDateSummaries = async () => {
+    try {
+      const response = await fetch('/api/todos/dates')
+      const data = await response.json()
+      setDateSummaries(Array.isArray(data) ? data : [])
+    } catch (error) {
+      console.error('Error fetching date summaries:', error)
+      setDateSummaries([])
     }
   }
 
@@ -46,7 +68,8 @@ export default function Home() {
       if (response.ok) {
         setInputText('')
         setPriority(1)
-        fetchTodos()
+        fetchTodos(selectedDate)
+        fetchDateSummaries()
       }
     } catch (error) {
       console.error('Error adding todo:', error)
@@ -60,7 +83,8 @@ export default function Home() {
       })
       
       if (response.ok) {
-        fetchTodos()
+        fetchTodos(selectedDate)
+        fetchDateSummaries()
       }
     } catch (error) {
       console.error('Error deleting todo:', error)
@@ -74,7 +98,8 @@ export default function Home() {
       })
       
       if (response.ok) {
-        fetchTodos()
+        fetchTodos(selectedDate)
+        fetchDateSummaries()
       }
     } catch (error) {
       console.error('Error toggling todo:', error)
@@ -92,17 +117,46 @@ export default function Home() {
       })
       
       if (response.ok) {
-        fetchTodos()
+        fetchTodos(selectedDate)
+        fetchDateSummaries()
       }
     } catch (error) {
       console.error('Error updating priority:', error)
     }
   }
 
+  const handleDateSelect = (date: string) => {
+    setSelectedDate(date)
+    fetchTodos(date)
+  }
+
+  const handleShowAll = () => {
+    setSelectedDate('')
+    fetchTodos()
+  }
+
   return (
     <div className="container">
       <h1>TODO App</h1>
       
+      <div className="date-selector">
+        <button 
+          onClick={handleShowAll}
+          className={selectedDate === '' ? 'active' : ''}
+        >
+          すべて
+        </button>
+        {dateSummaries.map((summary) => (
+          <button
+            key={summary.date}
+            onClick={() => handleDateSelect(summary.date)}
+            className={selectedDate === summary.date ? 'active' : ''}
+          >
+            {new Date(summary.date).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/\//g, '/')} ({summary.completed_count}/{summary.count})
+          </button>
+        ))}
+      </div>
+
       <AddTodoForm
         inputText={inputText}
         setInputText={setInputText}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- 新規日別タスクAPIエンドポイントの追加
- 日付フィルタリング機能の実装
- 日付表示形式をyyyy/mm/dd形式に改善

## Test plan
- [ ] 日付タブが正常に表示される
- [ ] 日付フィルタリングが正常に動作する
- [ ] 日付表示がyyyy/mm/dd形式になっている

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)